### PR TITLE
saba v2.0.1リリース - ContentUpdater管理セクション挿入位置を修正

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,7 +508,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "saba"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "askama",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "saba"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/shared/utils/content_updater.rs
+++ b/src/shared/utils/content_updater.rs
@@ -39,11 +39,11 @@ impl ContentUpdater {
             // Replace existing managed section
             regex.replace(&existing_content, new_section.as_str()).to_string()
         } else {
-            // Append new managed section (file doesn't have managed section yet)
+            // Prepend new managed section (file doesn't have managed section yet)
             if existing_content.is_empty() {
                 format!("{}\n\n", new_section)
             } else {
-                format!("{}\n{}\n\n", existing_content.trim(), new_section)
+                format!("{}\n\n{}", new_section, existing_content.trim())
             }
         };
 


### PR DESCRIPTION
- バージョンを2.0.1に更新:
  - Cargo.toml version = "2.0.1"
  - Cargo.lock自動更新

- ContentUpdater管理セクション挿入位置を修正:
  - update_managed_section()で新規挿入時の位置を修正
  - 修正前: 既存コンテンツの末尾に管理セクション追加
  - 修正後: ファイル先頭に管理セクション配置

- main.rs等での正しい挿入位置を実現:
  - saba管理コメントが未存在の場合、ファイル先頭に挿入
  - mod宣言がファイル先頭の適切な位置に配置
  - Rustコーディング規約に準拠

🤖 Generated with [Claude Code](https://claude.ai/code)