### PR TITLE
saba v2.0.2リリース - ContentUpdater自動管理セクションの書式を最適化

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "saba"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/shared/utils/content_updater.rs
+++ b/src/shared/utils/content_updater.rs
@@ -61,9 +61,9 @@ impl ContentUpdater {
         additional_content: Option<&str>,
     ) -> Result<()> {
         let managed_content = if module_declarations.is_empty() {
-            "\n".to_string()
+            "".to_string()
         } else {
-            format!("\n{}\n", module_declarations.join("\n"))
+            module_declarations.join("\n")
         };
 
         Self::update_managed_section(
@@ -104,9 +104,9 @@ impl ContentUpdater {
         import_statements: &[String],
     ) -> Result<()> {
         let managed_content = if import_statements.is_empty() {
-            "\n".to_string()
+            "".to_string()
         } else {
-            format!("\n{}\n", import_statements.join("\n"))
+            import_statements.join("\n")
         };
 
         Self::update_managed_section(
@@ -123,9 +123,9 @@ impl ContentUpdater {
         export_statements: &[String],
     ) -> Result<()> {
         let managed_content = if export_statements.is_empty() {
-            "\n".to_string()
+            "".to_string()
         } else {
-            format!("\n{}\n", export_statements.join("\n"))
+            export_statements.join("\n")
         };
 
         Self::update_managed_section(


### PR DESCRIPTION
- module_declarations.join("\n")形式に統一してコンパクト化
- 余分な改行を削除してv1スタイルの簡潔な書式に戻す
- 開発者が編集しない管理セクションの可読性よりコンパクト性を優先
- Rust、Python、JavaScript/TypeScriptの全言語で統一

🤖 Generated with [Claude Code](https://claude.ai/code)