### PR TITLE
saba v2.1.2リリース - saba guideコマンドMarkdownサポート追加とAI開発規則整備

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,7 +508,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "saba"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "anyhow",
  "askama",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "saba"
-version = "2.1.1"
+version = "2.1.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
- サポート言語一覧にMarkdownを追加
- saba.yml管理対象ファイル・ディレクトリの明確化
- AI向け開発規則セクションを新設
- sabaリポジトリ開発者向け内容を削除してsaba利用者向けに最適化
- バージョンを2.1.1から2.1.2に更新

🤖 Generated with [Claude Code](https://claude.ai/code)