### PR TITLE
TypeScript/JavaScriptバレルエクスポートのオプション化実装

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "saba"
-version = "2.1.2"
+version = "2.1.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/code_generation/language/javascript/module_generator.rs
+++ b/src/code_generation/language/javascript/module_generator.rs
@@ -68,9 +68,14 @@ impl JavaScriptModuleGenerator {
             export_declarations.push(format!("export * from './{}/index.js';", submodule.name()));
         }
 
-        // Generate index.js for all modules
-        let index_js_path = module_path.join("index.js");
-        ContentUpdater::update_js_index_file(&index_js_path, &export_declarations)?;
+        // Generate index.js only if explicitly defined in codefile
+        let has_explicit_index = module.files().iter()
+            .any(|f| f.name() == "index" || f.filename_with_extension("javascript") == "index.js");
+
+        if has_explicit_index {
+            let index_js_path = module_path.join("index.js");
+            ContentUpdater::update_js_index_file(&index_js_path, &export_declarations)?;
+        }
 
         Ok(())
     }

--- a/src/code_generation/language/typescript/module_generator.rs
+++ b/src/code_generation/language/typescript/module_generator.rs
@@ -53,9 +53,14 @@ impl TypeScriptModuleGenerator {
             export_declarations.push(format!("export * from './{}';", submodule.name()));
         }
 
-        // Generate index.ts for all modules
-        let index_ts_path = module_path.join("index.ts");
-        ContentUpdater::update_js_index_file(&index_ts_path, &export_declarations)?;
+        // Generate index.ts only if explicitly defined in codefile
+        let has_explicit_index = module.files().iter()
+            .any(|f| f.name() == "index" || f.filename_with_extension("typescript") == "index.ts");
+
+        if has_explicit_index {
+            let index_ts_path = module_path.join("index.ts");
+            ContentUpdater::update_js_index_file(&index_ts_path, &export_declarations)?;
+        }
 
         Ok(())
     }


### PR DESCRIPTION
- index.ts/index.jsは明示的にcodefileで指定された場合のみ生成
- Nuxtプロジェクトの自動インポート機能と競合しない設計に改善
- 従来の自動バレルエクスポート機能は明示的指定により継続利用可能
- Rust、Python、Go言語への影響なし
- バージョンを2.1.3に更新

🤖 Generated with [Claude Code](https://claude.ai/code)